### PR TITLE
fix: use `latest` api for filtering out prereleases

### DIFF
--- a/components/PlatformIcons.vue
+++ b/components/PlatformIcons.vue
@@ -44,10 +44,9 @@ const releaseUrls = ref({
 });
 
 const fetchReleases = async () => {
-  const response = await fetch('https://api.github.com/repos/NJUPT-SAST/sast-evento/releases');
+  const response = await fetch('https://api.github.com/repos/NJUPT-SAST/sast-evento/releases/latest');
 
-  const releases = await response.json();
-  const latestRelease = releases[0];
+  const latestRelease = await response.json();
 
   latestRelease.assets.forEach((asset) => {
     if (asset.name.includes('win')) {


### PR DESCRIPTION
这避免了普通用户被引导到 `nightly` / `*-rc` 等非正式版本

![image](https://github.com/user-attachments/assets/b6de1c14-81e8-4c19-ad7f-e10ac229213c)


